### PR TITLE
Suggested Updates to Protobufs and Topic Naming Conventions 

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,9 +3,9 @@
 This directory contains Protobuf schema definitions for DataHub messages. The files in this directory are described as follows:
 
 1. [common.proto](common.proto): defines generic, commonly used types, including timestamps and geometry
-2. [conadmin_to_datahub.proto](conadmin_to_datahub.proto): defines the interface messages from the ConAdmin to the DataHub, enabling the DataHub to stay in sync with changes made by the ConAdmin
+2. [conadmin.proto](conadmin.proto): defines the interface messages from the ConAdmin to the DataHub, enabling the DataHub to stay in sync with changes made by the ConAdmin
 3. [data_source.proto](data_source.proto): defines the DataSource object, representing each data provider, to be included in generated messages
-4. [datahub_to_conadmin.proto](datahub_to_conadmin.proto): defines the interface messages from the DataHub to the ConAdmin, including sharing of requested updates and newly registered devices
+4. [datahub.proto](datahub.proto): defines the interface messages from the DataHub to the ConAdmin, including sharing of requested updates and newly registered devices
 5. [field_device.proto](field_device.proto): defines the FieldDevice object, representing a connected work zone device (like an arrow board) sharing location along with other properties
 6. [project.proto](project.proto): defines the Project object, representing a construction project/funding source
 7. [road_sub_event.proto](road_sub_event.proto): defines the RoadSubEvent object, representing a small portion of a work zone with static properties (speed limit, worker presence, lane status)

--- a/schemas/conadmin.proto
+++ b/schemas/conadmin.proto
@@ -54,7 +54,7 @@ message WorkZoneUpdate {
 }
 
 
-// Individual Messages
+// Action Types - not to be used outside of the Interface Types defined above.
 message FieldDeviceUpdated {
     optional uint64 project_id = 1;
     optional uint64 work_zone_event_id = 2;

--- a/schemas/conadmin.proto
+++ b/schemas/conadmin.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package datahub.v1;
 
-option java_package = "wyo.dot.protobuf";
-option java_outer_classname = "ConAdminToDataHubProto";
+option java_package = "wyo.dot.protobuf.conadmin";
+option java_outer_classname = "ConAdminProto";
 option java_multiple_files = true;
 
 import "common.proto";
@@ -14,39 +14,42 @@ import "work_zone.proto";
 
 
 // Interface Messages
-message FieldDeviceUpdateMessage {
+message FieldDeviceUpdate {
     optional uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
-    oneof field_device_update_message {
-        FieldDeviceUpdated field_device_updated = 3;
+    // We use oneof here to support easy addition of new message types as the system evolves
+    oneof type {
+        FieldDeviceUpdate updated = 3;
     }
 }
 
-message VehicleLocationUpdateMessage {
+message VehicleLocationUpdate {
     optional uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
-    oneof vehicle_location_update_message {
-        VehicleLocationUpdated vehicle_location_updated = 3;
+    // We use oneof here to support easy addition of new message types as the system evolves
+    oneof type {
+        VehicleLocationUpdated updated = 3;
     }
 }
 
-message ProjectUpdateMessage {
+message ProjectUpdate {
     optional uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
-    oneof project_update_message {
-        ProjectCreated project_created = 3;
-        ProjectUpdated project_updated = 4;
-        ProjectRemoved project_removed = 5;
+    // We use oneof here to support easy addition of new message types as the system evolves
+    oneof type {
+        ProjectCreated created = 3;
+        ProjectUpdated updated = 4;
+        ProjectRemoved removed = 5;
     }
 }
 
-message WorkZoneUpdateMessage {
+message WorkZoneUpdate {
     optional uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
-    oneof work_zone_update_message {
-        WorkZoneCreated work_zone_created = 3;
-        WorkZoneUpdated work_zone_updated = 4;
-        WorkZoneRemoved work_zone_removed = 5;
+    oneof type {
+        WorkZoneCreated created = 3;
+        WorkZoneUpdated updated = 4;
+        WorkZoneRemoved removed = 5;
     }
 }
 

--- a/schemas/conadmin.proto
+++ b/schemas/conadmin.proto
@@ -6,7 +6,6 @@ option java_package = "wyo.dot.protobuf.conadmin";
 option java_outer_classname = "ConAdminProto";
 option java_multiple_files = true;
 
-import "common.proto";
 import "project.proto";
 import "google/protobuf/timestamp.proto";
 import "road_sub_event.proto";
@@ -14,24 +13,6 @@ import "work_zone.proto";
 
 
 // Interface Messages
-message FieldDeviceUpdate {
-    optional uint64 request_id = 1;
-    google.protobuf.Timestamp timestamp = 2;
-    // We use oneof here to support easy addition of new message types as the system evolves
-    oneof type {
-        FieldDeviceUpdate updated = 3;
-    }
-}
-
-message VehicleLocationUpdate {
-    optional uint64 request_id = 1;
-    google.protobuf.Timestamp timestamp = 2;
-    // We use oneof here to support easy addition of new message types as the system evolves
-    oneof type {
-        VehicleLocationUpdated updated = 3;
-    }
-}
-
 message ProjectUpdate {
     optional uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
@@ -43,7 +24,7 @@ message ProjectUpdate {
     }
 }
 
-message WorkZoneUpdate {
+message ConAdminWorkZoneUpdate {
     optional uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
     oneof type {
@@ -55,18 +36,6 @@ message WorkZoneUpdate {
 
 
 // Action Types - not to be used outside of the Interface Types defined above.
-message FieldDeviceUpdated {
-    optional uint64 project_id = 1;
-    optional uint64 work_zone_event_id = 2;
-    optional MarkedLocationType location_type = 3;
-}
-
-message VehicleLocationUpdated {
-    optional uint64 project_id = 1;
-    optional uint64 work_zone_event_id = 2;
-    optional MarkedLocationType location_type = 3;
-}
-
 message ProjectCreated {
     Project project = 2;
 }

--- a/schemas/conadmin.proto
+++ b/schemas/conadmin.proto
@@ -56,65 +56,54 @@ message WorkZoneUpdate {
 
 // Individual Messages
 message FieldDeviceUpdated {
-    uint64 id = 1;
-    optional uint64 project_id = 2;
-    optional uint64 work_zone_event_id = 3;
-    optional MarkedLocationType location_type = 4; 
+    optional uint64 project_id = 1;
+    optional uint64 work_zone_event_id = 2;
+    optional MarkedLocationType location_type = 3;
 }
 
 message VehicleLocationUpdated {
-    uint64 id = 1;
-    optional uint64 project_id = 2;
-    optional uint64 work_zone_event_id = 3;
-    optional MarkedLocationType location_type = 4; 
+    optional uint64 project_id = 1;
+    optional uint64 work_zone_event_id = 2;
+    optional MarkedLocationType location_type = 3;
 }
 
 message ProjectCreated {
-    uint64 id = 1;
     Project project = 2;
 }
 
 message ProjectUpdated {
-    uint64 id = 1;
     Project project = 2;
 }
 
 message ProjectRemoved {
-    uint64 id = 1;
     Project project = 2;
 }
 
 message WorkZoneCreated {
-    uint64 id = 1;
-    WorkZone work_zone = 2;
-    repeated RoadSubEventCreated road_sub_events_created = 3;
+    WorkZone work_zone = 1;
+    repeated RoadSubEventCreated road_sub_events_created = 2;
 }
 
 message WorkZoneUpdated {
-    uint64 id = 1;
-    WorkZone work_zone = 2;
-    repeated RoadSubEventCreated road_sub_events_created = 3;
-    repeated RoadSubEventUpdated road_sub_events_updated = 4;
-    repeated RoadSubEventRemoved road_sub_events_removed = 5;
+    WorkZone work_zone = 1;
+    repeated RoadSubEventCreated road_sub_events_created = 2;
+    repeated RoadSubEventUpdated road_sub_events_updated = 3;
+    repeated RoadSubEventRemoved road_sub_events_removed = 4;
 }
 
 message WorkZoneRemoved {
-    uint64 id = 1;
-    WorkZone work_zone = 2;
-    repeated RoadSubEvent road_sub_events = 3;
+    WorkZone work_zone = 1;
+    repeated RoadSubEvent road_sub_events = 2;
 }
 
 message RoadSubEventCreated {
-    uint64 id = 1;
-    RoadSubEvent road_sub_event = 2;
+    RoadSubEvent road_sub_event = 1;
 }
 
 message RoadSubEventUpdated {
-    uint64 id = 1;
-    RoadSubEvent road_sub_event = 2;
+    RoadSubEvent road_sub_event = 1;
 }
 
 message RoadSubEventRemoved {
-    uint64 id = 1;
-    RoadSubEvent road_sub_event = 2;
+    RoadSubEvent road_sub_event = 1;
 }

--- a/schemas/datahub.proto
+++ b/schemas/datahub.proto
@@ -35,7 +35,7 @@ message FieldDeviceUpdate {
     }
 }
 
-message WorkZoneUpdate {
+message DataHubWorkZoneUpdate {
     uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
 

--- a/schemas/datahub.proto
+++ b/schemas/datahub.proto
@@ -14,37 +14,42 @@ import "work_zone.proto";
 
 
 // Interface Messages
-message VehicleLocationUpdateRequestMessage {
+message VehicleLocationUpdate {
     uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
-    oneof field_device_update_request_message {
+
+    // We use oneof here to support easy addition of new message types as the system evolves
+    oneof type {
         UpdateVehicleLocation field_device_updated = 3;
     }
 }
 
-message FieldDeviceUpdateRequestMessage {
+message FieldDeviceUpdate {
     uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
-    oneof field_device_request_message {
+
+    // We use oneof here to support easy addition of new message types as the system evolves
+    oneof type {
         CreateFieldDevice field_device_created = 3;
         UpdateFieldDevice field_device_updated = 4;
     }
 }
 
-message WorkZoneUpdateRequestMessage {
+message WorkZoneUpdate {
     uint64 request_id = 1;
     google.protobuf.Timestamp timestamp = 2;
-    oneof field_device_update_request_message {
+
+    // We use oneof here to support easy addition of new message types as the system evolves
+    oneof type {
         CreateWorkZone work_zone_created = 3;
         UpdateWorkZone work_zone_updated = 4;
     }
 }
 
 
-// Individual Messages
+// Action Types - not to be used outside of the Interface Types defined above.
 message UpdateVehicleLocation {
-    uint64 id = 1;
-    VehicleLocation vehicle_location = 2;
+    VehicleLocation vehicle_location = 1;
 }
 
 message CreateFieldDevice {
@@ -52,8 +57,7 @@ message CreateFieldDevice {
 }
 
 message UpdateFieldDevice {
-    uint64 id = 1;
-    FieldDevice field_device = 2;
+    FieldDevice field_device = 1;
 }
 
 message CreateWorkZone {
@@ -63,12 +67,11 @@ message CreateWorkZone {
 }
 
 message UpdateWorkZone {
-    uint64 id = 1;
-    WorkZone work_zone = 2;
-    DataHubUpdateSource source = 3;
-    repeated CreateRoadSubEvent create_road_sub_events = 4;
-    repeated UpdateRoadSubEvent update_road_sub_events = 5;
-    repeated RemoveRoadSubEvent remove_road_sub_events = 6;
+    WorkZone work_zone = 1;
+    DataHubUpdateSource source = 2;
+    repeated CreateRoadSubEvent create_road_sub_events = 3;
+    repeated UpdateRoadSubEvent update_road_sub_events = 4;
+    repeated RemoveRoadSubEvent remove_road_sub_events = 5;
 }
 
 message CreateRoadSubEvent {
@@ -76,13 +79,11 @@ message CreateRoadSubEvent {
 }
 
 message UpdateRoadSubEvent {
-    uint64 id = 1;
-    RoadSubEvent road_sub_event = 2;
+    RoadSubEvent road_sub_event = 1;
 }
 
 message RemoveRoadSubEvent {
-    uint64 id = 1;
-    RoadSubEvent road_sub_event = 2;
+    RoadSubEvent road_sub_event = 1;
 }
 
 // Data Types
@@ -90,7 +91,7 @@ message ReportSummary {
     uint64 id = 1;
     string name = 2;
     string description = 3;
-    google.protobuf.Timestamp report_date = 4;
+    google.protobuf.Timestamp timestamp = 4;
     string contact_name = 5;
     string contact_phone = 6;
 }
@@ -99,7 +100,7 @@ message RecordingSummary {
     uint64 id = 1;
     string name = 2;
     string description = 3;
-    google.protobuf.Timestamp report_date = 4;
+    google.protobuf.Timestamp timestamp = 4;
     double length_meters = 5;
     double position_accuracy_meters = 6;
 }

--- a/schemas/kafka_topics.md
+++ b/schemas/kafka_topics.md
@@ -1,23 +1,49 @@
 # Kafka Topic Configuration
 
-- vehicle_location_updates
-  - schema: datahub.v1.conadmin_to_datahub.VehicleLocationUpdateMessage
-  - description: vehicle location changes coming from ConAdmin
-- field_device_updates
-  - schema: datahub.v1.conadmin_to_datahub.FieldDeviceUpdateMessage
-  - description: field device changes coming from ConAdmin
-- project_updates
-  - schema: datahub.v1.conadmin_to_datahub.ProjectUpdateMessage
-  - description: project changes coming from ConAdmin
-- work_zone_updates
-  - schema: datahub.v1.conadmin_to_datahub.WorkZoneUpdateMessage
-  - description: work zone changes coming from ConAdmin
-- datahub_vehicle_location_updates
-  - schema: datahub.v1.datahub_to_conadmin.VehicleLocationUpdateRequestMessage
-  - description: Requested vehicle location changes coming from DataHub
-- datahub_field_device_updates
-  - schema: datahub.v1.datahub_to_conadmin.FieldDeviceUpdateRequestMessage
-  - description: Requested field device changes coming from DataHub
-- datahub_work_zone_updates
-  - schema: datahub.v1.datahub_to_conadmin.WorkZoneUpdateRequestMessage
-  - description: Requested work zone changes coming from DataHub
+The naming conventions follow the suggested best practices
+from [Confluent](https://www.confluent.io/learn/kafka-topic-naming-convention/) for the Hierarchical Pattern. The
+separators we will use are `.` and `_`. The `.` indicates a change hierarchy. The `_` acts as a word separator. 
+
+## Structure of a name:
+
+`[data source].[data type]`
+
+### Data Source / Domain
+
+This identifies the system or domain where the data originates. In our case, either `conadmin` or `datahub`.
+
+### Data Type
+
+This identifies the type of data. In our case, something like `project` or `work_zone`.
+
+### Examples
+
+- `conadmin.project`
+- `datahub.work_zone`
+
+## ConAdmin
+
+- conadmin.vehicle_location
+    - schema: datahub.v1.conadmin.VehicleLocationUpdate
+    - description: vehicle location changes coming from ConAdmin
+- conadmin.field_device
+    - schema: datahub.v1.conadmin.FieldDeviceUpdate
+    - description: field device changes coming from ConAdmin
+- conadmin.project
+    - schema: datahub.v1.conadmin.ProjectUpdate
+    - description: project changes coming from ConAdmin
+- conadmin.work_zone
+    - schema: datahub.v1.conadmin.WorkZoneUpdate
+    - description: work zone changes coming from ConAdmin
+
+## Data Hub
+
+- datahub.vehicle_location
+    - schema: datahub.v1.datahub.VehicleLocationUpdateRequestMessage
+    - description: Requested vehicle location changes coming from DataHub
+- datahub.field_device
+    - schema: datahub.v1.datahub.FieldDeviceUpdateRequestMessage
+    - description: Requested field device changes coming from DataHub
+- datahub.work_zone
+    - schema: datahub.v1.datahub.WorkZoneUpdateRequestMessage
+    - description: Requested work zone changes coming from DataHub


### PR DESCRIPTION
# Summary

These are suggestions to restructure existing Protobuf schemas and improve their naming conventions. Documentation was also introduced to adopt Confluence's Best Practices for Kafka topic naming.

## Main changes:
### Restructuring Protobuf Schemas:

- Renamed and updated several fields/types across schemas to standardize and improve consistency.
- Renamed datahub_to_conadmin.proto to datahub.proto and conadmin_to_datahub to conadmin align with naming conventions.

### Documentation Updates:
- Updated README.md to align with the renamed Protobuf files.
- Updated kafka_topics.md with a new hierarchical topic naming convention and schema references to match the updated Protobufs.

### Naming Standardization:
- Adopted consistent field naming and message structure, improving clarity and maintainability.
- Removed unnecessary id fields from the Action Types since the `request_id` performs the same function in the Interface Types.